### PR TITLE
Parallel support for gradle and stack/ghc

### DIFF
--- a/src/main/scala/com/prezi/haskell/gradle/extension/impl/HaskellCompilationSupportImpl.scala
+++ b/src/main/scala/com/prezi/haskell/gradle/extension/impl/HaskellCompilationSupportImpl.scala
@@ -53,6 +53,10 @@ trait HaskellCompilationSupportImpl {
         if (conf.getName == Names.mainConfiguration) {
           val compileConfTask = createTask[CompileTask]("compile" + conf.getName.capitalize)
           compileConfTask.attachToSourceSet(sourceSet)
+          val parallelParameterName = "stack.parallelThreadCount"
+          if (project.hasProperty(parallelParameterName)) {
+            compileConfTask.setParallelThreadCount(Integer.valueOf(project.property(parallelParameterName).asInstanceOf[String]))
+          }
 
           compileConfTask.configuration = Some(conf)
           compileConfTask.tools = tools

--- a/src/main/scala/com/prezi/haskell/gradle/util/FileLock.scala
+++ b/src/main/scala/com/prezi/haskell/gradle/util/FileLock.scala
@@ -1,0 +1,20 @@
+package com.prezi.haskell.gradle.util
+
+import java.io.File
+
+import scala.util.Random
+
+class FileLock(file: File) {
+  def lock(): Unit = {
+    val random = new Random()
+    file.getParentFile.mkdirs()
+    // According to the javadoc, java.io.File.createNewFile should not be used for locking, but for this non-critical
+    // use-case it is a good enough solution.
+    while (!file.createNewFile())
+      Thread.sleep(random.nextInt(100))
+  }
+
+  def release(): Unit = {
+    file.delete()
+  }
+}


### PR DESCRIPTION
This PR support speeding up the build speed, by adding support for:
* gradle's `--parallel` flag
* ghc's parallel support via stack

### Implementation
Multiple `StoreDependentSandboxes` couldn't run in parallel, because they work in the root project's build directory.
This is fixed by using a file-based locking, that locks the whole sandbox store. Note that this could be fine-tuned because not all parts of the `StoreDependentSandboxes` need to lock this directory, but for simplicity's sake I did it this way.

Multiple `GenerateStackYaml` couldn't run in parallel, because they work in the user's home directory, execute a `git pull` there, this can't run in parallel, git will fail.
This is fixed the same way, by using a lock file in the root project's build directory. This fixes the issue for a single build, but multiple gradle builds still can't run in parallel (because it would require a global lock).

Added support for ghc parallel module build. It uses stack's [--ghc-options](https://docs.haskellstack.org/en/stable/GUIDE/?highlight=ghc-options#ghc-options) flag, the ghc options used is [`-jN`](https://downloads.haskell.org/~ghc/7.8.2/docs/html/users_guide/flag-reference.html#idp15539456), where `N` (the number of modules build parallelly) can be configured with the `stack.parallelThreadCount` gradle property. For example

    ./gradlew build -Pstack.parallelThreadCount=4

will build with `-j4`.

 The default is set to 3 because as [noted by others too](https://ghc.haskell.org/trac/ghc/ticket/910#comment:22), the performance/thread ratio seems to peak at `-j3`.